### PR TITLE
add errHandler definition to https.request

### DIFF
--- a/lib/rx_https.js
+++ b/lib/rx_https.js
@@ -33,6 +33,9 @@ exports.request = function (options) {
     handler = function (response) {
         subject.onNext(response);
     },
+    errHandler = function (err) {
+        subject.onError(err);
+    },
     observable = subject.asObservable();
     observable.request = https.request(options, handler).on('error', errHandler);
     return observable;
@@ -41,7 +44,7 @@ exports.get = function (options) {
     var subject = new Rx.Subject(),
     handler = function (response) {
         subject.onNext(response);
-    }
+    },
     errHandler = function (err) {
         subject.onError(err);
     };


### PR DESCRIPTION
`errHandler` is defined in the other exports for `http` & `https` but seems it was overlooked during `34feb3e`. just adding it in and cleanup function definition in `.get`
